### PR TITLE
fix: log user ID consistently in request logger

### DIFF
--- a/server/middleware/requestLogger.js
+++ b/server/middleware/requestLogger.js
@@ -18,7 +18,8 @@ export const requestLogger = (req, res, next) => {
       statusCode: res.statusCode,
       duration: `${duration}ms`,
       timestamp: new Date().toISOString(),
-      userId: req.user ? req.user._id : null,
+      // Use Prisma-style `id` if available, fallback to `_id` for legacy compatibility
+      userId: req.user ? req.user.id || req.user._id : null,
       userRole: req.user ? req.user.role : null,
     };
 


### PR DESCRIPTION
## Summary
- ensure request logger records user IDs from Prisma (`id`) and fall back to legacy `_id`

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/dom')*

------
https://chatgpt.com/codex/tasks/task_e_689b3c8c1dbc832ba2ce910faf241840