### PR TITLE
Hide sidebar navigation for unauthenticated users

### DIFF
--- a/client/components/layouts/UnifiedLayout.tsx
+++ b/client/components/layouts/UnifiedLayout.tsx
@@ -14,6 +14,7 @@ export const UnifiedLayout: React.FC<UnifiedLayoutProps> = ({
   className,
 }) => {
   const { isSidebarCollapsed } = useAppSelector((state) => state.ui);
+  const { isAuthenticated } = useAppSelector((state) => state.auth);
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -21,10 +22,12 @@ export const UnifiedLayout: React.FC<UnifiedLayoutProps> = ({
       <Navigation />
 
       <div className="flex pt-16">
-        {/* Sidebar Navigation - Hidden on mobile, always visible on desktop */}
-        <div className="hidden md:block sticky top-0 h-[calc(100vh-4rem)] overflow-y-auto">
-          <SimplifiedSidebarNav />
-        </div>
+        {/* Sidebar Navigation - Only visible when authenticated */}
+        {isAuthenticated && (
+          <div className="hidden md:block sticky top-0 h-[calc(100vh-4rem)] overflow-y-auto">
+            <SimplifiedSidebarNav />
+          </div>
+        )}
 
         {/* Main Content - Responsive margins */}
         <main


### PR DESCRIPTION
## Purpose
Hide the left navigation sidebar when users are not logged in to improve the user experience and prevent access to authenticated-only navigation elements.

## Code changes
- Added `isAuthenticated` selector from auth state in `UnifiedLayout.tsx`
- Wrapped the sidebar navigation component with conditional rendering based on authentication status
- Updated comments to reflect the new authentication-based visibility logic

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 27`

🔗 [Edit in Builder.io](https://builder.io/app/projects/dbc0e0ea6b11404d82201f6013b99cb7/pixel-realm)

👀 [Preview Link](https://dbc0e0ea6b11404d82201f6013b99cb7-pixel-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>dbc0e0ea6b11404d82201f6013b99cb7</projectId>-->
<!--<branchName>pixel-realm</branchName>-->